### PR TITLE
typos, clarify gravity node names

### DIFF
--- a/editor/nodes/actions/charactersetgravity.py
+++ b/editor/nodes/actions/charactersetgravity.py
@@ -8,7 +8,7 @@ from ...sockets import NodeSocketLogicVectorXYZVelocity
 @node_type
 class LogicNodeCharacterSetGravity(LogicNodeActionType):
     bl_idname = "NLActionSetCharacterGravity"
-    bl_label = "Set Gravity"
+    bl_label = "Set Character Gravity"
     nl_module = 'uplogic.nodes.actions'
     nl_class = "ULSetCharacterGravity"
 

--- a/editor/nodes/actions/setgravity.py
+++ b/editor/nodes/actions/setgravity.py
@@ -7,7 +7,7 @@ from ...sockets import NodeSocketLogicVectorXYZVelocity
 @node_type
 class LogicNodeSetGravity(LogicNodeActionType):
     bl_idname = "NLActionSetGravity"
-    bl_label = "Set Gravity"
+    bl_label = "Set World Gravity"
     nl_module = 'uplogic.nodes.actions'
     nl_class = "ULSetGravity"
 

--- a/editor/nodes/parameters/getgravity.py
+++ b/editor/nodes/parameters/getgravity.py
@@ -6,7 +6,7 @@ from ...sockets import NodeSocketLogicVectorXYZ
 @node_type
 class LogicNodeGetGravity(LogicNodeParameterType):
     bl_idname = "NLGetGravityNode"
-    bl_label = "Get Gravity"
+    bl_label = "Get World Gravity"
     nl_module = 'uplogic.nodes.parameters'
 
     def init(self, context):

--- a/ops/applylogictree.py
+++ b/ops/applylogictree.py
@@ -15,7 +15,7 @@ import bpy
 class LOGIC_NODES_OT_apply_logic_tree(Operator):
     bl_idname = "logic_nodes.apply_logic_tree"
     bl_label = "Apply Logic"
-    bl_description = "Apply the current tree to the selected objects."
+    bl_description = "Apply the current tree to selected objects"
     bl_options = {'REGISTER', 'UNDO'}
 
     owner: StringProperty()

--- a/ops/installupbgestubs.py
+++ b/ops/installupbgestubs.py
@@ -11,8 +11,8 @@ class LOGIC_NODES_OT_install_upbge_stubs(Operator):
     bl_idname = "logic_nodes.install_upbge_stubs"
     bl_label = "Install or Update BGE Stub Module"
     bl_description = (
-        'Downloads the latest version of the upbge-stubs module to support autocomplet in your IDE.'
-        'NOTE: This may take a few seconds and requires internet connection.'
+        'Downloads the latest version of the upbge-stubs module to support autocomplete in your IDE.\n'
+        'NOTE: This may take a few seconds and requires internet connection'
     )
     bl_options = {'REGISTER', 'UNDO'}
 

--- a/ops/installuplogic.py
+++ b/ops/installuplogic.py
@@ -14,7 +14,7 @@ class LOGIC_NODES_OT_install_uplogic(Operator):
     bl_description = (
         'Downloads the latest version of the uplogic module required for '
         'running logic nodes.\n\n'
-        'NOTE: This may take a few seconds and requires internet connection.'
+        'NOTE: This may take a few seconds and requires internet connection'
     )
     bl_options = {'REGISTER', 'UNDO'}
 


### PR DESCRIPTION
- typos - blender adds a dot ( . ) at the end of panel sentence automatically > removed few dots from _bge_netlogic_ files
- renamed gravity nodes to clarify naming