### PR TITLE
OSC nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist/
 /uplogic.egg-info/
 __pycache__
+todo_osc.md

--- a/editor/nodes/__init__.py
+++ b/editor/nodes/__init__.py
@@ -345,4 +345,8 @@ from .fmod.fmodgeteventparameter import LogicNodeFModGetEventParameter
 from .fmod.fmodseteventparameter import LogicNodeFModSetEventParameter
 from .fmod.fmodmodifyeventparameter import LogicNodeFModModifyEventParameter
 
+from .actions.oscsend import LogicNodeSendOSC
+from .actions.oscsetupserver import LogicNodeOSCSetupServer
+from .actions.oscreceive import LogicNodeOSCReceive
+
 # from .groupnode import NodeGroupInputLogic

--- a/editor/nodes/__init__.py
+++ b/editor/nodes/__init__.py
@@ -345,7 +345,7 @@ from .fmod.fmodgeteventparameter import LogicNodeFModGetEventParameter
 from .fmod.fmodseteventparameter import LogicNodeFModSetEventParameter
 from .fmod.fmodmodifyeventparameter import LogicNodeFModModifyEventParameter
 
-from .actions.oscsend import LogicNodeSendOSC
+from .actions.oscsend import LogicNodeOSCSend
 from .actions.oscsetupserver import LogicNodeOSCSetupServer
 from .actions.oscreceive import LogicNodeOSCReceive
 

--- a/editor/nodes/actions/oscreceive.py
+++ b/editor/nodes/actions/oscreceive.py
@@ -2,7 +2,6 @@ from ..node import node_type
 from ..node import LogicNodeActionType
 from ...sockets import NodeSocketLogicCondition
 from ...sockets import NodeSocketLogicString
-from ...sockets import NodeSocketLogicIntegerPositive
 from ...sockets import NodeSocketLogicDictionary
 from ...sockets import NodeSocketLogicParameter
 
@@ -20,7 +19,12 @@ class LogicNodeOSCReceive(LogicNodeActionType):
         self.add_input(NodeSocketLogicString, "OSC Address", "osc_address", {'default_value':"/osc"})
         
         #Outputs
+        # RECEIVED -> True when any message matches address
         self.add_output(NodeSocketLogicCondition, "Received", "RECEIVED")
+        # MESSAGES -> Dictionary {address: value} of all addresses that match
+        self.add_output(NodeSocketLogicDictionary, "Messages", "MESSAGES")
+        # VALUE -> If only one address matches: Outputs its value (For addresses without wilcards)
+        # Else -> Output first or last from dictionary // No outputs (For adresses with wildcards)
         self.add_output(NodeSocketLogicParameter, "Value", "VALUE")
         
         #Init

--- a/editor/nodes/actions/oscreceive.py
+++ b/editor/nodes/actions/oscreceive.py
@@ -1,0 +1,27 @@
+from ..node import node_type
+from ..node import LogicNodeActionType
+from ...sockets import NodeSocketLogicCondition
+from ...sockets import NodeSocketLogicString
+from ...sockets import NodeSocketLogicIntegerPositive
+from ...sockets import NodeSocketLogicDictionary
+from ...sockets import NodeSocketLogicParameter
+
+@node_type
+class LogicNodeOSCReceive(LogicNodeActionType):
+    bl_idname = "LogicNodeOSCReceive"
+    bl_label = "Receive OSC Message"
+    bl_description = "Receive OSC messages from a given address"
+    nl_module = 'uplogic.nodes.actions'
+    nl_class = "ULOSCReceive"
+    
+    def init(self, context):
+        #Inputs
+        self.add_input(NodeSocketLogicDictionary, "Messages", "messages")
+        self.add_input(NodeSocketLogicString, "OSC Address", "osc_address", {'default_value':"/osc"})
+        
+        #Outputs
+        self.add_output(NodeSocketLogicCondition, "Received", "RECEIVED")
+        self.add_output(NodeSocketLogicParameter, "Value", "VALUE")
+        
+        #Init
+        LogicNodeActionType.init(self, context)

--- a/editor/nodes/actions/oscsend.py
+++ b/editor/nodes/actions/oscsend.py
@@ -1,0 +1,29 @@
+from ..node import node_type
+from ..node import LogicNodeActionType
+from ...sockets import NodeSocketLogicCondition
+from ...sockets import NodeSocketLogicString
+from ...sockets import NodeSocketLogicIntegerPositive
+from ...sockets import NodeSocketLogicDictionary
+
+@node_type
+class LogicNodeSendOSC(LogicNodeActionType):
+    bl_idname = "LogicNodeSendOSC"
+    bl_label = "Send OSC Message"
+    bl_description = "Send OSC messages to a given address"
+    bl_width_default = 180
+    nl_module = 'uplogic.nodes.actions'
+    nl_class = "ULSendOSC"
+    
+    def init(self, context):
+        #Inputs
+        self.add_input(NodeSocketLogicCondition, "Condition", "condition")
+        self.add_input(NodeSocketLogicString, "IP", "ip", {'default_value': "127.0.0.1"})
+        self.add_input(NodeSocketLogicIntegerPositive, "Port", 'port', {'default_value': 5005})
+        self.add_input(NodeSocketLogicString, "OSC Address", "osc", {'default_value': "/osc"})
+        self.add_input(NodeSocketLogicDictionary, "Data", "data")
+        
+        #Outputs
+        self.add_output(NodeSocketLogicCondition, "Done", "DONE")
+        
+        #Init
+        LogicNodeActionType.init(self, context)

--- a/editor/nodes/actions/oscsend.py
+++ b/editor/nodes/actions/oscsend.py
@@ -6,8 +6,8 @@ from ...sockets import NodeSocketLogicIntegerPositive
 from ...sockets import NodeSocketLogicDictionary
 
 @node_type
-class LogicNodeSendOSC(LogicNodeActionType):
-    bl_idname = "LogicNodeSendOSC"
+class LogicNodeOSCSend(LogicNodeActionType):
+    bl_idname = "LogicNodeOSCSend"
     bl_label = "Send OSC Message"
     bl_description = "Send OSC messages to a given address"
     bl_width_default = 180

--- a/editor/nodes/actions/oscsend.py
+++ b/editor/nodes/actions/oscsend.py
@@ -12,7 +12,7 @@ class LogicNodeOSCSend(LogicNodeActionType):
     bl_description = "Send OSC messages to a given address"
     bl_width_default = 180
     nl_module = 'uplogic.nodes.actions'
-    nl_class = "ULSendOSC"
+    nl_class = "ULOSCSend"
     
     def init(self, context):
         #Inputs

--- a/editor/nodes/actions/oscsetupserver.py
+++ b/editor/nodes/actions/oscsetupserver.py
@@ -1,0 +1,32 @@
+from ..node import node_type
+from ..node import LogicNodeActionType
+from ...sockets import NodeSocketLogicCondition
+from ...sockets import NodeSocketLogicString
+from ...sockets import NodeSocketLogicIntegerPositive
+from ...sockets import NodeSocketLogicDictionary
+from ...sockets import NodeSocketLogicBoolean
+
+@node_type
+class LogicNodeOSCSetupServer(LogicNodeActionType):
+    bl_idname = "LogicNodeOSCSetupServer"
+    bl_label = "Setup OSC Server"
+    bl_description = 'Manage an Open Sound Control (OSC) server'
+    bl_width_default = 180
+    nl_module = 'uplogic.nodes.actions'
+    nl_class = "ULOSCSetupServer"
+    
+    def init(self, context):
+        #Inputs
+        self.add_input(NodeSocketLogicCondition, "Start", "condition_start")
+        self.add_input(NodeSocketLogicCondition, "Stop", "condition_stop")
+        self.add_input(NodeSocketLogicString, "IP", "ip", {'default_value': "127.0.0.1"})
+        self.add_input(NodeSocketLogicIntegerPositive, "Port", "port", {'default_value': 9001})
+        #(Remove OSC Filter)
+        self.add_input(NodeSocketLogicString, "Default Address", "default_address", {'default_value': "/osc"})
+        self.add_input(NodeSocketLogicBoolean, "Debug", "debug")
+        
+        #Oututs
+        self.add_output(NodeSocketLogicDictionary, "Messages", "MESSAGES")
+        
+        #Init
+        LogicNodeActionType.init(self, context)

--- a/ui/node_menu.py
+++ b/ui/node_menu.py
@@ -888,6 +888,10 @@ class NetworkMenu(bpy.types.Menu):
         insertNode(layout, "LogicNodeRebuildData", "Rebuild Data")
         insertNode(layout, "LogicNodeSendNetworkMessage", "Send Data")
         insertNode(layout, "LogicNodeSerializeData", "Serialize Data")
+        layout.separator()
+        insertNode(layout, "LogicNodeOSCSetupServer", "Setup OSC Server")
+        insertNode(layout, "LogicNodeOSCReceive", "Receive OSC Message")
+        insertNode(layout, "LogicNodeOSCSend", "Send OSC Message")
 
 @menu_item
 class PathMenu(bpy.types.Menu):


### PR DESCRIPTION
# Pull request - OSC nodes
## Summary

Added three new OSC nodes: OSC Setup Server, OSC Receive, OSC Send.

![Captura de tela 2025-03-12 181910](https://github.com/user-attachments/assets/1eb60e1e-5288-406e-ad2a-8d7ccef27951)

## List of changes

- Added files to `editor/nodes/actions` -> `oscsetupserver.py`, `oscreceive.py`, `oscsend.py`
- Changed lines in `editor/nodes/__init__.py` -> Import the new nodes
- Changed lines in `ui/node_menu.py` -> Added the new nodes to the Network tab

## Checks

- [x] Addon compiles
- [x] Nodes found in the UI
- [x] Nodes can be added
- [ ] Nodes compile (not yet)
- [ ] Nodes are working (not yet)

## Further comments

- The uplogic class names were changed, so some of them don't match with my old code. The new ones are: `ULOSCSetupServer`, `ULOSCReceive`, `ULOSCSend`
- Some other nodes from the previous version weren't added (OSC Filter, OSC Listener, OSC Sequencer), to avoid UI clutter.
- "OSC Setup Server" has a new input: "Default Adress". This was previously included in OSC Filter.

## TO-DO

- [ ] "OSC Receive" should support regex matching with OSC style addresses (like /osc/*/guitar). For that, it should have two outputs: Messages (dictionary), Value (parameter/float/list) 
- [ ] Uplogic classes should be updated and cleaned up


